### PR TITLE
[BACKPORT] GDB: Fix detection of ELF support when configuring with -W…

### DIFF
--- a/gdb/acinclude.m4
+++ b/gdb/acinclude.m4
@@ -359,6 +359,7 @@ AC_DEFUN([GDB_AC_CHECK_BFD], [
   AC_CACHE_CHECK([$1], [$2],
   [AC_TRY_LINK(
   [#include <stdlib.h>
+  #include <string.h>
   #include "bfd.h"
   #include "$4"
   ],

--- a/gdb/configure
+++ b/gdb/configure
@@ -16392,6 +16392,7 @@ else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <stdlib.h>
+  #include <string.h>
   #include "bfd.h"
   #include "elf-bfd.h"
 
@@ -16503,6 +16504,7 @@ else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <stdlib.h>
+  #include <string.h>
   #include "bfd.h"
   #include "mach-o.h"
 


### PR DESCRIPTION
…error=implicit-function-declaration

I am getting

    I'm sorry, Dave, I can't do that.  Symbol format `elf64-littleriscv' unknown.

errors after updating from GDB 8.3 to 10.  Bisecting showed that since
commit 1ff6de031241 ("bfd, ld: add CTF section linking"), bfd.h depends
on strncmp() being present, so configuring with
-Werror=implicit-function-declaration results in the check for ELF
support in BFD failing:

    .../gdb/gdb/../bfd/elf-bfd.h: In function 'bfd_section_is_ctf':
    .../gdb/gdb/../bfd/elf-bfd.h:3086:10: error: implicit declaration of function 'strncmp' [-Werror=implicit-function-declaration]
       return strncmp (name, ".ctf", 4) == 0 && (name[4] == 0 || name[4] == '.');

gdb/ChangeLog:

	* acincludde.m4 (GDB_AC_CHECK_BFD): Include string.h in the test
	program.

Change-Id: Iec5e21d454c2a544c44d65e23cfde552c424c18e

Backport from b413232211bf7c7754095b017f27774d70646489

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>