### PR TITLE
readline: Assume "unknown" terminal type by default

### DIFF
--- a/readline/readline/terminal.c
+++ b/readline/readline/terminal.c
@@ -444,7 +444,7 @@ _rl_init_terminal_io (const char *terminal_name)
   tty = rl_instream ? fileno (rl_instream) : 0;
 
   if (term == 0)
-    term = "dumb";
+    term = "unknown";
 
 #ifdef __MSDOS__
   _rl_term_im = _rl_term_ei = _rl_term_ic = _rl_term_IC = (char *)NULL;


### PR DESCRIPTION
This patch modifies the `_rl_init_terminal_io` function to pass
`unknown` terminal type instead of `dumb` when no terminal name is
provided by the caller (e.g. when the `TERM` environment variable is
not set on Win32).

This ensures that the termcap provider (e.g. ncurses) resolves the
default preferred terminal type instead of using the `dumb` terminal
type.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>