### PR TITLE
microblaze: Invalid data offsets (pointer) after relaxation.

### DIFF
--- a/bfd/elf32-microblaze.c
+++ b/bfd/elf32-microblaze.c
@@ -1967,6 +1967,9 @@ microblaze_elf_relax_section (bfd *abfd,
 	    {
 	      if (ELF32_R_TYPE (irelscan->r_info) == (int) R_MICROBLAZE_32)
 		{
+			if (ELF32_R_SYM (irelscan->r_info) >= symtab_hdr->sh_info)
+				continue;
+
 		  isym = isymbuf + ELF32_R_SYM (irelscan->r_info);
 
 		  /* Look at the reloc only if the value has been resolved.  */
@@ -1999,6 +2002,9 @@ microblaze_elf_relax_section (bfd *abfd,
 		    }
 		  else if (ELF32_R_TYPE (irelscan->r_info) == (int) R_MICROBLAZE_32_SYM_OP_SYM)
 		    {
+		      if (ELF32_R_SYM (irelscan->r_info) >= symtab_hdr->sh_info)
+		        continue;
+
 		      isym = isymbuf + ELF32_R_SYM (irelscan->r_info);
 
 		      /* Look at the reloc only if the value has been resolved.  */
@@ -2036,6 +2042,9 @@ microblaze_elf_relax_section (bfd *abfd,
 		       || (ELF32_R_TYPE (irelscan->r_info)
 				   == (int) R_MICROBLAZE_TEXTREL_32_LO))
 		{
+		  if (ELF32_R_SYM (irelscan->r_info) >= symtab_hdr->sh_info)
+		    continue;
+
 		  isym = isymbuf + ELF32_R_SYM (irelscan->r_info);
 
 		  /* Look at the reloc only if the value has been resolved.  */
@@ -2082,6 +2091,9 @@ microblaze_elf_relax_section (bfd *abfd,
 		  || (ELF32_R_TYPE (irelscan->r_info)
 			      == (int) R_MICROBLAZE_TEXTREL_64))
 		{
+		  if (ELF32_R_SYM (irelscan->r_info) >= symtab_hdr->sh_info)
+		    continue;
+
 		  isym = isymbuf + ELF32_R_SYM (irelscan->r_info);
 
 		  /* Look at the reloc only if the value has been resolved.  */
@@ -2116,6 +2128,9 @@ microblaze_elf_relax_section (bfd *abfd,
 		}
 	      else if (ELF32_R_TYPE (irelscan->r_info) == (int) R_MICROBLAZE_64_PCREL)
 		{
+		  if (ELF32_R_SYM (irelscan->r_info) >= symtab_hdr->sh_info)
+		    continue;
+
 		  isym = isymbuf + ELF32_R_SYM (irelscan->r_info);
 
 		  /* Look at the reloc only if the value has been resolved.  */


### PR DESCRIPTION
Proposed patch from community member (dednev@rambler.ru) against 2021.1 [CR-1115232]

Patch file taken and partially applied from:
https://github.com/Xilinx/meta-xilinx/blob/master/meta-microblaze/recipes-devtools/binutils/binutils/0038-Invalid-data-offsets-pointer-after-relaxation.-Propo.patch