### PR TITLE
arc: Fix alignment of the TLS Translation Control Block (from upstream)

### DIFF
--- a/bfd/elfnn-arc.c
+++ b/bfd/elfnn-arc.c
@@ -1291,10 +1291,8 @@ arc_special_overflow_checks (const struct arc_relocation_data reloc_data,
   (bfd_signed_vma) (reloc_data.sym_section->output_section->vma)
 #define JLI (bfd_signed_vma) (reloc_data.sym_section->output_section->vma)
 #define _SDA_BASE_ (bfd_signed_vma) (reloc_data.sdata_begin_symbol_vma)
-#define TLS_REL (bfd_signed_vma)				\
-  ((elf_hash_table (info))->tls_sec->output_section->vma)
-#define TLS_TBSS (align_power(TCB_SIZE,					\
-			      reloc_data.sym_section->alignment_power))
+#define TLS_REL (bfd_signed_vma)(tls_sec->output_section->vma)
+#define TLS_TBSS (align_power (TCB_SIZE, tls_sec->alignment_power))
 #define ICARRY insn
 #define DEREFP (insn)
 
@@ -1375,6 +1373,7 @@ arc_do_relocation (bfd_byte * contents,
   bfd * abfd = reloc_data.input_section->owner;
   struct elf_link_hash_table *htab ATTRIBUTE_UNUSED = elf_hash_table (info);
   bfd_reloc_status_type flag;
+  asection *tls_sec = htab->tls_sec;
 
   if (!reloc_data.should_relocate)
     return bfd_reloc_ok;
@@ -1408,6 +1407,19 @@ arc_do_relocation (bfd_byte * contents,
     }
 
   orig_insn = insn;
+
+  /* If we resolve a TLS relocation, make sure we do have a valid TLS
+     section.  */
+  switch (reloc_data.howto->type)
+    {
+    case R_ARC_TLS_LE_32:
+      if (tls_sec == NULL)
+	return bfd_reloc_notsupported;
+      break;
+
+    default:
+      break;
+    }
 
   switch (reloc_data.howto->type)
     {


### PR DESCRIPTION
The R_ARC_TLS_LE_32 is defined as S + A + TLS_TBSS - TLS_REL, where

  -  S is the base address of the symbol in the memory
  -  A is the symbol addendum
  -  TLS_TBSS is the TLS Translation Control Block size (aligned)
  -  TLS_REL is the base of the TLS section

Given the next code snip:

__thread int data_var = 12;
__attribute__((__aligned__(128))) __thread int data_var_128 = 128; __thread int bss_var;
__attribute__((__aligned__(256))) __thread int bss_var_256;

int __start(void)
{
	return data_var + data_var_128 + bss_var + bss_var_256;
}

The current code returns different TLS_TBSS values for .tdata and .tbss. This patch fixes this by using the linker provided tls_sec.