### PR TITLE
elf: Workaround for segment first section address check in phdr rewrite

### DIFF
--- a/bfd/elf.c
+++ b/bfd/elf.c
@@ -7412,7 +7412,7 @@ rewrite_elf_program_header (bfd *ibfd, bfd *obfd, bfd_vma maxpagesize)
 		      /* If the first section in a segment does not start at
 			 the beginning of the segment, then something is
 			 wrong.  */
-		      if (align_power (map->p_paddr
+		      if ((align_power (map->p_paddr
 				       + (map->includes_filehdr
 					  ? iehdr->e_ehsize : 0)
 				       + (map->includes_phdrs
@@ -7420,6 +7420,7 @@ rewrite_elf_program_header (bfd *ibfd, bfd *obfd, bfd_vma maxpagesize)
 					  : 0),
 				       output_section->alignment_power * opb)
 			  != output_section->lma * opb)
+			  && (map->p_paddr != output_section->lma * opb))
 			goto sorry;
 		    }
 		  else


### PR DESCRIPTION
rewrite_elf_program_header() currently makes a questionable assumption that the LMA of a segment will be aligned at the alignment of the first section in the segment, and attempts to align the address of the segment LMA to the alignment of the first section using align_power() before comparing it to the actual LMA of the first section for the purpose of verifying that the first section starts at the beginning of the segment.

This is not a problem when the LMA is equal to the VMA and both are aligned at the section alignment; but, for the sections that have different VMA and LMA, only the VMA is guaranteed to be aligned at the section alignment, and the LMA may or may not be aligned at the same boundary, leading to rewrite_elf_program_header() returning false even for valid ELF files that do not contain any segments whose first section does not start at the beginning of the segment.

This patch adds an alternate check directly comparing the segment and section LMAs for the segments that do not contain any headers; in case a segment contains a file or program header, the function may still erroneously return false.

A more fundamental fix should re-implement the function such that it uses VMA for verifying that the first section in a segment starts at the beginning of the segment.

---

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/58080