### PR TITLE
Fix GCC 13 compatibility issues for MinGW-w64

### DIFF
--- a/gdb/configure
+++ b/gdb/configure
@@ -14767,6 +14767,7 @@ else
     # endif
     #endif	/* __MINGW32__ || __CYGWIN__ */
     #include <thread>
+    #include <mutex>
     void callback() { }
 int
 main ()

--- a/gdb/configure
+++ b/gdb/configure
@@ -14756,8 +14756,18 @@ if ${gdb_cv_cxx_std_thread+:} false; then :
 else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-#include <thread>
-      void callback() { }
+  #if defined (__MINGW32__) || defined (__CYGWIN__)
+    # ifdef _WIN32_WINNT
+    #  if _WIN32_WINNT < 0x0501
+    #   undef _WIN32_WINNT
+    #   define _WIN32_WINNT 0x0501
+    #  endif
+    # else
+    #  define _WIN32_WINNT 0x0501
+    # endif
+    #endif	/* __MINGW32__ || __CYGWIN__ */
+    #include <thread>
+    void callback() { }
 int
 main ()
 {

--- a/gdbserver/configure
+++ b/gdbserver/configure
@@ -7953,6 +7953,7 @@ else
     # endif
     #endif	/* __MINGW32__ || __CYGWIN__ */
     #include <thread>
+    #include <mutex>
     void callback() { }
 int
 main ()

--- a/gdbserver/configure
+++ b/gdbserver/configure
@@ -7942,8 +7942,18 @@ if ${gdb_cv_cxx_std_thread+:} false; then :
 else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-#include <thread>
-      void callback() { }
+  #if defined (__MINGW32__) || defined (__CYGWIN__)
+    # ifdef _WIN32_WINNT
+    #  if _WIN32_WINNT < 0x0501
+    #   undef _WIN32_WINNT
+    #   define _WIN32_WINNT 0x0501
+    #  endif
+    # else
+    #  define _WIN32_WINNT 0x0501
+    # endif
+    #endif	/* __MINGW32__ || __CYGWIN__ */
+    #include <thread>
+    void callback() { }
 int
 main ()
 {

--- a/gdbsupport/common-defs.h
+++ b/gdbsupport/common-defs.h
@@ -70,7 +70,9 @@
 
 /* We don't support Windows versions before XP, so we define
    _WIN32_WINNT correspondingly to ensure the Windows API headers
-   expose the required symbols.  */
+   expose the required symbols.
+
+   NOTE: this must be kept in sync with common.m4.  */
 #if defined (__MINGW32__) || defined (__CYGWIN__)
 # ifdef _WIN32_WINNT
 #  if _WIN32_WINNT < 0x0501

--- a/gdbsupport/common.m4
+++ b/gdbsupport/common.m4
@@ -101,7 +101,17 @@ AC_DEFUN([GDB_AC_COMMON], [
     AC_CACHE_CHECK([for std::thread],
 		   gdb_cv_cxx_std_thread,
 		   [AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
-    [[#include <thread>
+    [[#if defined (__MINGW32__) || defined (__CYGWIN__)
+      # ifdef _WIN32_WINNT
+      #  if _WIN32_WINNT < 0x0501
+      #   undef _WIN32_WINNT
+      #   define _WIN32_WINNT 0x0501
+      #  endif
+      # else
+      #  define _WIN32_WINNT 0x0501
+      # endif
+      #endif	/* __MINGW32__ || __CYGWIN__ */
+      #include <thread>
       void callback() { }]],
     [[std::thread t(callback);]])],
 				  gdb_cv_cxx_std_thread=yes,

--- a/gdbsupport/common.m4
+++ b/gdbsupport/common.m4
@@ -112,6 +112,7 @@ AC_DEFUN([GDB_AC_COMMON], [
       # endif
       #endif	/* __MINGW32__ || __CYGWIN__ */
       #include <thread>
+      #include <mutex>
       void callback() { }]],
     [[std::thread t(callback);]])],
 				  gdb_cv_cxx_std_thread=yes,

--- a/gdbsupport/configure
+++ b/gdbsupport/configure
@@ -8968,6 +8968,7 @@ else
     # endif
     #endif	/* __MINGW32__ || __CYGWIN__ */
     #include <thread>
+    #include <mutex>
     void callback() { }
 int
 main ()

--- a/gdbsupport/configure
+++ b/gdbsupport/configure
@@ -8957,8 +8957,18 @@ if ${gdb_cv_cxx_std_thread+:} false; then :
 else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-#include <thread>
-      void callback() { }
+  #if defined (__MINGW32__) || defined (__CYGWIN__)
+    # ifdef _WIN32_WINNT
+    #  if _WIN32_WINNT < 0x0501
+    #   undef _WIN32_WINNT
+    #   define _WIN32_WINNT 0x0501
+    #  endif
+    # else
+    #  define _WIN32_WINNT 0x0501
+    # endif
+    #endif	/* __MINGW32__ || __CYGWIN__ */
+    #include <thread>
+    void callback() { }
 int
 main ()
 {


### PR DESCRIPTION
This series pulls in the patches that fix the issues when compiling GDB with GCC 13 and above for MinGW-w64.