### PR TITLE
Patches from zephyr-binutils-2_38

### DIFF
--- a/bfd/elf32-microblaze.c
+++ b/bfd/elf32-microblaze.c
@@ -2031,6 +2031,9 @@ microblaze_elf_relax_section (bfd *abfd,
 	      if ((ELF32_R_TYPE (irelscan->r_info) == (int) R_MICROBLAZE_32)
 		  || (ELF32_R_TYPE (irelscan->r_info) == (int) R_MICROBLAZE_32_NONE))
 		{
+			if (ELF32_R_SYM (irelscan->r_info) >= symtab_hdr->sh_info)
+				continue;
+
 		  isym = isymbuf + ELF32_R_SYM (irelscan->r_info);
 
 		  /* Look at the reloc only if the value has been resolved.  */
@@ -2063,6 +2066,9 @@ microblaze_elf_relax_section (bfd *abfd,
 		    }
 		  else if (ELF32_R_TYPE (irelscan->r_info) == (int) R_MICROBLAZE_32_SYM_OP_SYM)
 		    {
+		      if (ELF32_R_SYM (irelscan->r_info) >= symtab_hdr->sh_info)
+		        continue;
+
 		      isym = isymbuf + ELF32_R_SYM (irelscan->r_info);
 
 		      /* Look at the reloc only if the value has been resolved.  */
@@ -2100,6 +2106,9 @@ microblaze_elf_relax_section (bfd *abfd,
 		       || (ELF32_R_TYPE (irelscan->r_info)
 			   == (int) R_MICROBLAZE_TEXTREL_32_LO))
 		{
+		  if (ELF32_R_SYM (irelscan->r_info) >= symtab_hdr->sh_info)
+		    continue;
+
 		  isym = isymbuf + ELF32_R_SYM (irelscan->r_info);
 
 		  /* Look at the reloc only if the value has been resolved.  */
@@ -2146,6 +2155,9 @@ microblaze_elf_relax_section (bfd *abfd,
 		  || (ELF32_R_TYPE (irelscan->r_info)
 			      == (int) R_MICROBLAZE_TEXTREL_64))
 		{
+		  if (ELF32_R_SYM (irelscan->r_info) >= symtab_hdr->sh_info)
+		    continue;
+
 		  isym = isymbuf + ELF32_R_SYM (irelscan->r_info);
 
 		  /* Look at the reloc only if the value has been resolved.  */
@@ -2180,6 +2192,9 @@ microblaze_elf_relax_section (bfd *abfd,
 		}
 	      else if (ELF32_R_TYPE (irelscan->r_info) == (int) R_MICROBLAZE_64_PCREL)
 		{
+		  if (ELF32_R_SYM (irelscan->r_info) >= symtab_hdr->sh_info)
+		    continue;
+
 		  isym = isymbuf + ELF32_R_SYM (irelscan->r_info);
 
 		  /* Look at the reloc only if the value has been resolved.  */


### PR DESCRIPTION
This series includes the patches from the `zephyr-binutils-2_38` branch that are still relevant.

For more details, see https://github.com/zephyrproject-rtos/sdk-ng/issues/941