### PR TITLE
Patches from zephyr-gdb-12.1

### DIFF
--- a/gdb/arch-utils.c
+++ b/gdb/arch-utils.c
@@ -1130,6 +1130,13 @@ default_update_call_site_pc (struct gdbarch *gdbarch, CORE_ADDR pc)
   return pc;
 }
 
+/* See arch-utils.h  */
+int
+default_remote_supports_g_packet (struct gdbarch *gdbarch)
+{
+  return 1;
+}
+
 /* Non-zero if we want to trace architecture code.  */
 
 #ifndef GDBARCH_DEBUG

--- a/gdb/arch-utils.h
+++ b/gdb/arch-utils.h
@@ -414,4 +414,7 @@ extern enum return_value_convention default_gdbarch_return_value
       struct regcache *regcache, struct value **read_value,
       const gdb_byte *writebuf);
 
+/* Default implementation of gdbarch remote_supports_g_packet method.  */
+extern int default_remote_supports_g_packet (struct gdbarch *gdbarch);
+
 #endif /* GDB_ARCH_UTILS_H */

--- a/gdb/arch/xtensa.h
+++ b/gdb/arch/xtensa.h
@@ -20,6 +20,8 @@
 #ifndef GDB_ARCH_XTENSA_H
 #define GDB_ARCH_XTENSA_H
 
+#include <stdint.h>
+
 /* Xtensa ELF core file register set representation ('.reg' section).
    Copied from target-side ELF header <xtensa/elf.h>.  */
 

--- a/gdb/configure
+++ b/gdb/configure
@@ -976,6 +976,7 @@ with_babeltrace
 with_libbabeltrace_prefix
 with_libbabeltrace_type
 enable_libctf
+enable_xtensa_use_target_regnum
 enable_unit_tests
 '
       ac_precious_vars='build_alias
@@ -1662,6 +1663,8 @@ Optional Features:
   --enable-libbacktrace   use libbacktrace to write a backtrace after a fatal
                           signal.
   --enable-libctf         Handle .ctf type-info sections [default=yes]
+  --enable-xtensa-use-target-regnum
+                          Use remote target register numbers (Xtensa target)
   --enable-unit-tests     Enable the inclusion of unit tests when compiling
                           GDB
 
@@ -11500,7 +11503,7 @@ else
   lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
   lt_status=$lt_dlunknown
   cat > conftest.$ac_ext <<_LT_EOF
-#line 11503 "configure"
+#line 11506 "configure"
 #include "confdefs.h"
 
 #if HAVE_DLFCN_H
@@ -11606,7 +11609,7 @@ else
   lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
   lt_status=$lt_dlunknown
   cat > conftest.$ac_ext <<_LT_EOF
-#line 11609 "configure"
+#line 11612 "configure"
 #include "confdefs.h"
 
 #if HAVE_DLFCN_H
@@ -33635,6 +33638,23 @@ fi
 
 # If nativefile (NAT_FILE) is not set in configure.nat, we link to an
 # empty version.
+
+# Xtensa to use target register number
+# Check whether --enable-xtensa-use-target-regnum was given.
+if test "${enable_xtensa_use_target_regnum+set}" = set; then :
+  enableval=$enable_xtensa_use_target_regnum; case $enableval in
+    yes | no)
+      enable_xtensa_use_target_regnum=$enableval ;;
+    *)
+      as_fn_error $? "bad value $enableval for --enable-xtensa-use-target-regnum" "$LINENO" 5 ;;
+  esac
+else
+  enable_xtensa_use_target_regnum=no
+fi
+
+if test x"$enable_xtensa_use_target_regnum" = xyes; then
+  CPPFLAGS="$CPPFLAGS -DXTENSA_USE_TGT_REGNUM"
+fi
 
 NM_H=
 rm -f nm.h

--- a/gdb/configure
+++ b/gdb/configure
@@ -977,6 +977,7 @@ with_libbabeltrace_prefix
 with_libbabeltrace_type
 enable_libctf
 enable_xtensa_use_target_regnum
+enable_xtensa_remote_g_packet
 enable_unit_tests
 '
       ac_precious_vars='build_alias
@@ -1665,6 +1666,8 @@ Optional Features:
   --enable-libctf         Handle .ctf type-info sections [default=yes]
   --enable-xtensa-use-target-regnum
                           Use remote target register numbers (Xtensa target)
+  --disable-xtensa-remote-g-packet
+                          Disable g packet for remote Xtensa target
   --enable-unit-tests     Enable the inclusion of unit tests when compiling
                           GDB
 
@@ -11503,7 +11506,7 @@ else
   lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
   lt_status=$lt_dlunknown
   cat > conftest.$ac_ext <<_LT_EOF
-#line 11506 "configure"
+#line 11509 "configure"
 #include "confdefs.h"
 
 #if HAVE_DLFCN_H
@@ -11609,7 +11612,7 @@ else
   lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
   lt_status=$lt_dlunknown
   cat > conftest.$ac_ext <<_LT_EOF
-#line 11612 "configure"
+#line 11615 "configure"
 #include "confdefs.h"
 
 #if HAVE_DLFCN_H
@@ -33654,6 +33657,23 @@ fi
 
 if test x"$enable_xtensa_use_target_regnum" = xyes; then
   CPPFLAGS="$CPPFLAGS -DXTENSA_USE_TGT_REGNUM"
+fi
+
+# Use g packet for remote Xtensa target
+# Check whether --enable-xtensa-remote-g-packet was given.
+if test "${enable_xtensa_remote_g_packet+set}" = set; then :
+  enableval=$enable_xtensa_remote_g_packet; case $enableval in
+    yes | no)
+      enable_xtensa_use_g_packet=$enableval ;;
+    *)
+      as_fn_error $? "bad value $enableval for --enable-xtensa-remote-g-packet" "$LINENO" 5 ;;
+  esac
+else
+  enable_xtensa_use_g_packet=yes
+fi
+
+if test x"$enable_xtensa_use_g_packet" = xno; then
+  CPPFLAGS="$CPPFLAGS -DXTENSA_DISABLE_REMOTE_G_PACKET"
 fi
 
 NM_H=

--- a/gdb/configure.ac
+++ b/gdb/configure.ac
@@ -2244,6 +2244,20 @@ if test x"$enable_xtensa_use_target_regnum" = xyes; then
   CPPFLAGS="$CPPFLAGS -DXTENSA_USE_TGT_REGNUM"
 fi
 
+# Use g packet for remote Xtensa target
+AC_ARG_ENABLE(xtensa-remote-g-packet,
+AS_HELP_STRING([--disable-xtensa-remote-g-packet], [Disable g packet for remote Xtensa target]),
+  [case $enableval in
+    yes | no)
+      enable_xtensa_use_g_packet=$enableval ;;
+    *)
+      AC_MSG_ERROR([bad value $enableval for --enable-xtensa-remote-g-packet]) ;;
+  esac],
+  [enable_xtensa_use_g_packet=yes])
+if test x"$enable_xtensa_use_g_packet" = xno; then
+  CPPFLAGS="$CPPFLAGS -DXTENSA_DISABLE_REMOTE_G_PACKET"
+fi
+
 NM_H=
 rm -f nm.h
 if test "${nativefile}" != ""; then

--- a/gdb/configure.ac
+++ b/gdb/configure.ac
@@ -2230,6 +2230,20 @@ AC_SUBST(CTF_DEPS)
 # If nativefile (NAT_FILE) is not set in configure.nat, we link to an
 # empty version.
 
+# Xtensa to use target register number
+AC_ARG_ENABLE(xtensa-use-target-regnum,
+AS_HELP_STRING([--enable-xtensa-use-target-regnum], [Use remote target register numbers (Xtensa target)]),
+  [case $enableval in
+    yes | no)
+      enable_xtensa_use_target_regnum=$enableval ;;
+    *)
+      AC_MSG_ERROR([bad value $enableval for --enable-xtensa-use-target-regnum]) ;;
+  esac],
+  [enable_xtensa_use_target_regnum=no])
+if test x"$enable_xtensa_use_target_regnum" = xyes; then
+  CPPFLAGS="$CPPFLAGS -DXTENSA_USE_TGT_REGNUM"
+fi
+
 NM_H=
 rm -f nm.h
 if test "${nativefile}" != ""; then

--- a/gdb/gdbarch-gen.c
+++ b/gdb/gdbarch-gen.c
@@ -261,6 +261,7 @@ struct gdbarch
   gdbarch_read_core_file_mappings_ftype *read_core_file_mappings = default_read_core_file_mappings;
   gdbarch_use_target_description_from_corefile_notes_ftype *use_target_description_from_corefile_notes = default_use_target_description_from_corefile_notes;
   gdbarch_core_parse_exec_context_ftype *core_parse_exec_context = default_core_parse_exec_context;
+  gdbarch_remote_supports_g_packet_ftype *remote_supports_g_packet = default_remote_supports_g_packet;
 };
 
 /* Create a new ``struct gdbarch'' based on information provided by
@@ -533,6 +534,7 @@ verify_gdbarch (struct gdbarch *gdbarch)
   /* Skip verify of read_core_file_mappings, invalid_p == 0.  */
   /* Skip verify of use_target_description_from_corefile_notes, invalid_p == 0.  */
   /* Skip verify of core_parse_exec_context, invalid_p == 0.  */
+  /* Skip verify of remote_supports_g_packet, invalid_p == 0.  */
   if (!log.empty ())
     internal_error (_("verify_gdbarch: the following are invalid ...%s"),
 		    log.c_str ());
@@ -1401,6 +1403,9 @@ gdbarch_dump (struct gdbarch *gdbarch, struct ui_file *file)
   gdb_printf (file,
 	      "gdbarch_dump: core_parse_exec_context = <%s>\n",
 	      host_address_to_string (gdbarch->core_parse_exec_context));
+  gdb_printf (file,
+	      "gdbarch_dump: remote_supports_g_packet = <%s>\n",
+	      host_address_to_string (gdbarch->remote_supports_g_packet));
   if (gdbarch->dump_tdep != NULL)
     gdbarch->dump_tdep (gdbarch, file);
 }
@@ -5528,4 +5533,21 @@ set_gdbarch_core_parse_exec_context (struct gdbarch *gdbarch,
 				     gdbarch_core_parse_exec_context_ftype core_parse_exec_context)
 {
   gdbarch->core_parse_exec_context = core_parse_exec_context;
+}
+
+int
+gdbarch_remote_supports_g_packet (struct gdbarch *gdbarch)
+{
+  gdb_assert (gdbarch != NULL);
+  gdb_assert (gdbarch->remote_supports_g_packet != NULL);
+  if (gdbarch_debug >= 2)
+    gdb_printf (gdb_stdlog, "gdbarch_remote_supports_g_packet called\n");
+  return gdbarch->remote_supports_g_packet (gdbarch);
+}
+
+void
+set_gdbarch_remote_supports_g_packet (struct gdbarch *gdbarch,
+				      gdbarch_remote_supports_g_packet_ftype remote_supports_g_packet)
+{
+  gdbarch->remote_supports_g_packet = remote_supports_g_packet;
 }

--- a/gdb/gdbarch-gen.h
+++ b/gdb/gdbarch-gen.h
@@ -1793,3 +1793,9 @@ extern void set_gdbarch_use_target_description_from_corefile_notes (struct gdbar
 typedef core_file_exec_context (gdbarch_core_parse_exec_context_ftype) (struct gdbarch *gdbarch, bfd *cbfd);
 extern core_file_exec_context gdbarch_core_parse_exec_context (struct gdbarch *gdbarch, bfd *cbfd);
 extern void set_gdbarch_core_parse_exec_context (struct gdbarch *gdbarch, gdbarch_core_parse_exec_context_ftype *core_parse_exec_context);
+
+/* No comment */
+
+typedef int (gdbarch_remote_supports_g_packet_ftype) (struct gdbarch *gdbarch);
+extern int gdbarch_remote_supports_g_packet (struct gdbarch *gdbarch);
+extern void set_gdbarch_remote_supports_g_packet (struct gdbarch *gdbarch, gdbarch_remote_supports_g_packet_ftype *remote_supports_g_packet);

--- a/gdb/gdbarch_components.py
+++ b/gdb/gdbarch_components.py
@@ -2835,3 +2835,14 @@ which all assume current_inferior() is the one to read from.
     predefault="default_core_parse_exec_context",
     invalid=False,
 )
+
+Method(
+    comment="""
+Return 1 if arch supports 'g' packets
+""",
+    type="int",
+    name="remote_supports_g_packet",
+    params=[],
+    predefault="default_remote_supports_g_packet",
+    invalid=False,
+)

--- a/gdb/microblaze-tdep.c
+++ b/gdb/microblaze-tdep.c
@@ -370,16 +370,8 @@ microblaze_analyze_prologue (struct gdbarch *gdbarch, CORE_ADDR pc,
 static CORE_ADDR
 microblaze_unwind_pc (struct gdbarch *gdbarch, const frame_info_ptr &next_frame)
 {
-  gdb_byte buf[4];
   CORE_ADDR pc;
-
-  frame_unwind_register (next_frame, MICROBLAZE_PC_REGNUM, buf);
-  pc = extract_typed_address (buf, builtin_type (gdbarch)->builtin_func_ptr);
-  /* For sentinel frame, return address is actual PC.  For other frames,
-     return address is pc+8.  This is a workaround because gcc does not
-     generate correct return address in CIE.  */
-  if (frame_relative_level (next_frame) >= 0)
-    pc += 8;
+  pc=frame_unwind_register_unsigned (next_frame, MICROBLAZE_PC_REGNUM);
   return pc;
 }
 
@@ -486,7 +478,8 @@ static const struct frame_unwind microblaze_frame_unwind =
   microblaze_frame_this_id,
   microblaze_frame_prev_register,
   NULL,
-  default_frame_sniffer
+  default_frame_sniffer,
+  NULL,
 };
 
 static CORE_ADDR

--- a/gdb/remote.c
+++ b/gdb/remote.c
@@ -1893,6 +1893,7 @@ map_regcache_remote_table (struct gdbarch *gdbarch, struct packet_reg *regs)
 {
   int regnum, num_remote_regs, offset;
   struct packet_reg **remote_regs;
+  int remote_supports_g_packet;
 
   for (regnum = 0; regnum < gdbarch_num_regs (gdbarch); regnum++)
     {
@@ -1922,9 +1923,11 @@ map_regcache_remote_table (struct gdbarch *gdbarch, struct packet_reg *regs)
 	     [] (const packet_reg *a, const packet_reg *b)
 	      { return a->pnum < b->pnum; });
 
+  remote_supports_g_packet = gdbarch_remote_supports_g_packet(gdbarch);
+
   for (regnum = 0, offset = 0; regnum < num_remote_regs; regnum++)
     {
-      remote_regs[regnum]->in_g_packet = 1;
+      remote_regs[regnum]->in_g_packet = remote_supports_g_packet;
       remote_regs[regnum]->offset = offset;
       offset += register_size (gdbarch, remote_regs[regnum]->regnum);
     }

--- a/gdb/remote.c
+++ b/gdb/remote.c
@@ -8869,6 +8869,7 @@ remote_target::fetch_register_using_p (struct regcache *regcache,
   char *buf, *p;
   gdb_byte *regp = (gdb_byte *) alloca (register_size (gdbarch, reg->regnum));
   int i;
+  enum bfd_architecture bfd_arch = gdbarch_bfd_arch_info (gdbarch)->arch;
 
   if (m_features.packet_support (PACKET_p) == PACKET_DISABLE)
     return 0;
@@ -8893,6 +8894,15 @@ remote_target::fetch_register_using_p (struct regcache *regcache,
     case PACKET_UNKNOWN:
       return 0;
     case PACKET_ERROR:
+      /* On Xtensa, some privileged registers cannot be read using 'p'
+         packet. So keep these marked as unavailable so GDB can still
+         fetch other registers instead of stopping at error.  */
+      if (bfd_arch == bfd_arch_xtensa)
+        {
+          regcache->raw_supply (reg->regnum, NULL);
+          return 1;
+        }
+
       error (_("Could not fetch register \"%s\"; remote failure reply '%s'"),
 	     gdbarch_register_name (regcache->arch (), reg->regnum),
 	     result.err_msg ());

--- a/gdb/remote.c
+++ b/gdb/remote.c
@@ -8970,11 +8970,17 @@ remote_target::process_g_packet (struct regcache *regcache)
   buf_len = strlen (rs->buf.data ());
 
   /* Further sanity checks, with knowledge of the architecture.  */
-  if (buf_len > 2 * rsa->sizeof_g_packet)
-    error (_("Remote 'g' packet reply is too long (expected %ld bytes, got %d "
-	     "bytes): %s"),
-	   rsa->sizeof_g_packet, buf_len / 2,
-	   rs->buf.data ());
+   if(buf_len > 2 * rsa->sizeof_g_packet) {
+        rsa->sizeof_g_packet = buf_len;
+        for(i = 0; i < gdbarch_num_regs(gdbarch); i++){
+            if(rsa->regs[i].pnum == -1)
+               continue;
+            if(rsa->regs[i].offset >= rsa->sizeof_g_packet)
+               rsa->regs[i].in_g_packet = 0;
+            else
+               rsa->regs[i].in_g_packet = 1;
+        }
+  }
 
   /* Save the size of the packet sent to us by the target.  It is used
      as a heuristic when determining the max size of packets that the

--- a/gdb/remote.c
+++ b/gdb/remote.c
@@ -3443,21 +3443,21 @@ static int remote_newthread_step (threadref *ref, void *context);
 char *
 remote_target::write_ptid (char *buf, const char *endbuf, ptid_t ptid)
 {
-  int pid, tid;
+  long pid, tid;
 
   if (m_features.remote_multi_process_p ())
     {
       pid = ptid.pid ();
       if (pid < 0)
-	buf += xsnprintf (buf, endbuf - buf, "p-%x.", -pid);
+	buf += xsnprintf (buf, endbuf - buf, "p-%lx.", -pid);
       else
-	buf += xsnprintf (buf, endbuf - buf, "p%x.", pid);
+	buf += xsnprintf (buf, endbuf - buf, "p%lx.", pid);
     }
   tid = ptid.lwp ();
   if (tid < 0)
-    buf += xsnprintf (buf, endbuf - buf, "-%x", -tid);
+    buf += xsnprintf (buf, endbuf - buf, "-%lx", -tid);
   else
-    buf += xsnprintf (buf, endbuf - buf, "%x", tid);
+    buf += xsnprintf (buf, endbuf - buf, "%lx", tid);
 
   return buf;
 }

--- a/gdb/xtensa-tdep.c
+++ b/gdb/xtensa-tdep.c
@@ -3161,6 +3161,16 @@ xtensa_remote_register_number (struct gdbarch *gdbarch, int regnum)
 }
 #endif
 
+static int
+xtensa_remote_supports_g_packet (struct gdbarch *gdbarch)
+{
+#ifdef XTENSA_DISABLE_REMOTE_G_PACKET
+  return 0;
+#else
+  return 1;
+#endif
+}
+
 /* Module "constructor" function.  */
 
 extern xtensa_register_t xtensa_rmap[];
@@ -3260,6 +3270,8 @@ xtensa_gdbarch_init (struct gdbarch_info info, struct gdbarch_list *arches)
 
   set_solib_svr4_fetch_link_map_offsets
     (gdbarch, svr4_ilp32_fetch_link_map_offsets);
+
+  set_gdbarch_remote_supports_g_packet (gdbarch, xtensa_remote_supports_g_packet);
 
   /* Hook in the ABI-specific overrides, if they have been registered.  */
   gdbarch_init_osabi (info, gdbarch);

--- a/gdb/xtensa-tdep.c
+++ b/gdb/xtensa-tdep.c
@@ -3146,6 +3146,21 @@ xtensa_derive_tdep (xtensa_gdbarch_tdep *tdep)
   tdep->max_register_virtual_size = max_size;
 }
 
+#ifdef XTENSA_USE_TGT_REGNUM
+static int
+xtensa_remote_register_number (struct gdbarch *gdbarch, int regnum)
+{
+  xtensa_gdbarch_tdep *tdep = gdbarch_tdep<xtensa_gdbarch_tdep> (gdbarch);
+
+  /* Return the name stored in the register map.  */
+  if (regnum >= 0 && regnum < gdbarch_num_cooked_regs (gdbarch))
+    return tdep->regmap[regnum].target_number;
+
+  internal_error (__FILE__, __LINE__, _("invalid register %d"), regnum);
+  return regnum;
+}
+#endif
+
 /* Module "constructor" function.  */
 
 extern xtensa_register_t xtensa_rmap[];
@@ -3193,6 +3208,10 @@ xtensa_gdbarch_init (struct gdbarch_info info, struct gdbarch_list *arches)
   /* We provide our own function to get register information.  */
   set_gdbarch_register_name (gdbarch, xtensa_register_name);
   set_gdbarch_register_type (gdbarch, xtensa_register_type);
+
+#ifdef XTENSA_USE_TGT_REGNUM
+  set_gdbarch_remote_register_number (gdbarch, xtensa_remote_register_number);
+#endif
 
   /* To call functions from GDB using dummy frame.  */
   set_gdbarch_push_dummy_call (gdbarch, xtensa_push_dummy_call);

--- a/readline/readline/terminal.c
+++ b/readline/readline/terminal.c
@@ -478,7 +478,7 @@ _rl_init_terminal_io (const char *terminal_name)
   tty = rl_instream ? fileno (rl_instream) : 0;
 
   if (term == 0)
-    term = "dumb";
+    term = "unknown";
 
   dumbterm = STREQ (term, "dumb");
 


### PR DESCRIPTION
This series includes the patches from the `zephyr-gdb-12.1` branch that are still relevant.

For more details, see https://github.com/zephyrproject-rtos/sdk-ng/issues/941