### PR TITLE
gdb: Set default _WIN32_WINNT to 0x0600

### DIFF
--- a/gdb/configure
+++ b/gdb/configure
@@ -20892,7 +20892,7 @@ else
     #   define _WIN32_WINNT 0x0501
     #  endif
     # else
-    #  define _WIN32_WINNT 0x0501
+    #  define _WIN32_WINNT 0x0600
     # endif
     #endif	/* __MINGW32__ || __CYGWIN__ */
     #include <thread>

--- a/gdbserver/configure
+++ b/gdbserver/configure
@@ -9592,7 +9592,7 @@ else
     #   define _WIN32_WINNT 0x0501
     #  endif
     # else
-    #  define _WIN32_WINNT 0x0501
+    #  define _WIN32_WINNT 0x0600
     # endif
     #endif	/* __MINGW32__ || __CYGWIN__ */
     #include <thread>

--- a/gdbsupport/common-defs.h
+++ b/gdbsupport/common-defs.h
@@ -87,7 +87,7 @@
 #   define _WIN32_WINNT 0x0501
 #  endif
 # else
-#  define _WIN32_WINNT 0x0501
+#  define _WIN32_WINNT 0x0600
 # endif
 #endif	/* __MINGW32__ || __CYGWIN__ */
 

--- a/gdbsupport/common.m4
+++ b/gdbsupport/common.m4
@@ -138,7 +138,7 @@ AC_CHECK_HEADERS([ \
     #   define _WIN32_WINNT 0x0501
     #  endif
     # else
-    #  define _WIN32_WINNT 0x0501
+    #  define _WIN32_WINNT 0x0600
     # endif
     #endif	/* __MINGW32__ || __CYGWIN__ */
     #include <thread>

--- a/gdbsupport/configure
+++ b/gdbsupport/configure
@@ -12366,7 +12366,7 @@ else
     #   define _WIN32_WINNT 0x0501
     #  endif
     # else
-    #  define _WIN32_WINNT 0x0501
+    #  define _WIN32_WINNT 0x0600
     # endif
     #endif	/* __MINGW32__ || __CYGWIN__ */
     #include <thread>


### PR DESCRIPTION
When `_WIN32_WINNT` is not defined in CFLAGS, default to 0x0600 (Vista/Server 2008 or later) because libstdc++, when building with the win32 thread model, only supports `std::mutex` and `std:condition_variable` if `_WIN32_WINNT >= 0x0600`.

---

Fixes https://github.com/zephyrproject-rtos/sdk-ng/issues/964