### PR TITLE
microblaze: apply binutils patches from meta-Xilinx repository

### DIFF
--- a/bfd/elf-eh-frame.c
+++ b/bfd/elf-eh-frame.c
@@ -1045,10 +1045,13 @@ _bfd_elf_parse_eh_frame (bfd *abfd, struct bfd_link_info *info,
   goto success;
 
  free_no_table:
+/* FIXME: Remove the microblaze specifics when relaxing gets fixed.  */
+if (bfd_get_arch(abfd) != bfd_arch_microblaze) {
   _bfd_error_handler
     /* xgettext:c-format */
     (_("error in %pB(%pA); no .eh_frame_hdr table will be created"),
      abfd, sec);
+}
   hdr_info->u.dwarf.table = false;
   free (sec_info);
  success:

--- a/bfd/elf32-microblaze.c
+++ b/bfd/elf32-microblaze.c
@@ -177,9 +177,9 @@ static reloc_howto_type microblaze_elf_howto_raw[] =
    /* This reloc does nothing.	Used for relaxation.  */
    HOWTO (R_MICROBLAZE_32_NONE,	/* Type.  */
 	0,			/* Rightshift.  */
-	2,			/* Size (0 = byte, 1 = short, 2 = long).  */
+	4,			/* Size */
 	32,			/* Bitsize.  */
-	true,			/* PC_relative.  */
+	false,			/* PC_relative.  */
 	0,			/* Bitpos.  */
 	complain_overflow_bitfield, /* Complain on overflow.  */
 	NULL,			/* Special Function.  */

--- a/bfd/elf32-microblaze.c
+++ b/bfd/elf32-microblaze.c
@@ -1766,10 +1766,8 @@ microblaze_elf_relax_section (bfd *abfd,
 {
   Elf_Internal_Shdr *symtab_hdr;
   Elf_Internal_Rela *internal_relocs;
-  Elf_Internal_Rela *free_relocs = NULL;
   Elf_Internal_Rela *irel, *irelend;
   bfd_byte *contents = NULL;
-  bfd_byte *free_contents = NULL;
   int rel_count;
   unsigned int shndx;
   size_t i, sym_index;
@@ -1813,8 +1811,6 @@ microblaze_elf_relax_section (bfd *abfd,
   internal_relocs = _bfd_elf_link_read_relocs (abfd, sec, NULL, NULL, link_info->keep_memory);
   if (internal_relocs == NULL)
     goto error_return;
-  if (! link_info->keep_memory)
-    free_relocs = internal_relocs;
 
   sdata->relax_count = 0;
   sdata->relax = (struct relax_table *) bfd_malloc ((sec->reloc_count + 1)
@@ -1842,7 +1838,6 @@ microblaze_elf_relax_section (bfd *abfd,
 	      contents = (bfd_byte *) bfd_malloc (sec->size);
 	      if (contents == NULL)
 		goto error_return;
-	      free_contents = contents;
 
 	      if (!bfd_get_section_contents (abfd, sec, contents,
 					     (file_ptr) 0, sec->size))
@@ -2288,25 +2283,26 @@ microblaze_elf_relax_section (bfd *abfd,
 	}
 
       elf_section_data (sec)->relocs = internal_relocs;
-      free_relocs = NULL;
 
       elf_section_data (sec)->this_hdr.contents = contents;
-      free_contents = NULL;
 
       symtab_hdr->contents = (bfd_byte *) isymbuf;
     }
 
-  free (free_relocs);
-  free_relocs = NULL;
+  if (internal_relocs != NULL
+      && elf_section_data (sec)->relocs != internal_relocs)
+    free (internal_relocs);
 
-  if (free_contents != NULL)
-    {
-      if (!link_info->keep_memory)
-	free (free_contents);
+  if (contents != NULL
+      && elf_section_data (sec)->this_hdr.contents != contents)
+   {
+      if (! link_info->keep_memory)
+	free (contents);
       else
-	/* Cache the section contents for elf_link_input_bfd.  */
-	elf_section_data (sec)->this_hdr.contents = contents;
-      free_contents = NULL;
+	{
+	  /* Cache the section contents for elf_link_input_bfd.  */
+	  elf_section_data (sec)->this_hdr.contents = contents;
+	}
     }
 
   if (sdata->relax_count == 0)
@@ -2320,8 +2316,16 @@ microblaze_elf_relax_section (bfd *abfd,
   return true;
 
  error_return:
-  free (free_relocs);
-  free (free_contents);
+ 
+  if (isymbuf != NULL
+      && symtab_hdr->contents != (unsigned char *) isymbuf)
+    free (isymbuf);
+  if (internal_relocs != NULL
+      && elf_section_data (sec)->relocs != internal_relocs)
+    free (internal_relocs);
+  if (contents != NULL
+      && elf_section_data (sec)->this_hdr.contents != contents)
+    free (contents);
   free (sdata->relax);
   sdata->relax = NULL;
   sdata->relax_count = 0;

--- a/gas/config/tc-microblaze.c
+++ b/gas/config/tc-microblaze.c
@@ -37,6 +37,8 @@
 
 #define OPTION_EB (OPTION_MD_BASE + 0)
 #define OPTION_EL (OPTION_MD_BASE + 1)
+#define OPTION_LITTLE (OPTION_MD_BASE + 2)
+#define OPTION_BIG (OPTION_MD_BASE + 3)
 
 void microblaze_generate_symbol (char *sym);
 static bool check_spl_reg (unsigned *);
@@ -2565,9 +2567,11 @@ md_parse_option (int c, const char * arg ATTRIBUTE_UNUSED)
   switch (c)
     {
     case OPTION_EB:
+    case OPTION_BIG:
       target_big_endian = 1;
       break;
     case OPTION_EL:
+    case OPTION_LITTLE:
       target_big_endian = 0;
       break;
     default:

--- a/gas/expr.c
+++ b/gas/expr.c
@@ -832,6 +832,15 @@ operand (expressionS *expressionP, enum expr_mode mode)
 	      break;
 	    }
 	}
+      if ((*input_line_pointer == 'U') || (*input_line_pointer == 'u'))
+      {
+      input_line_pointer--;
+
+      integer_constant ((NUMBERS_WITH_SUFFIX || flag_m68k_mri)
+                        ? 0 : 10,
+                        expressionP);
+      break;
+      }
       c = *input_line_pointer;
       switch (c)
 	{

--- a/ld/ldmain.c
+++ b/ld/ldmain.c
@@ -1608,6 +1608,18 @@ reloc_overflow (struct bfd_link_info *info,
 	  break;
 	case bfd_link_hash_defined:
 	case bfd_link_hash_defweak:
+
+         if((strcmp(reloc_name,"R_MICROBLAZE_SRW32") == 0) &&  entry->type == bfd_link_hash_defined)
+	  {
+	  einfo (_(" relocation truncated to fit: don't enable small data pointer optimizations[mxl-gp-opt] if extern or multiple declarations used: "
+		 "%s against symbol `%T' defined in %A section in %B"),
+                 reloc_name, entry->root.string,
+                 entry->u.def.section,
+                 entry->u.def.section == bfd_abs_section_ptr
+                  ? info->output_bfd : entry->u.def.section->owner);
+	      break;
+	  }
+
 	  einfo (_(" relocation truncated to fit: "
 		   "%s against symbol `%pT' defined in %pA section in %pB"),
 		 reloc_name, entry->root.string,


### PR DESCRIPTION
Re-do of the exercise in #10 but using the newer patchset which apparently is based on 2.42

This patchset fixes many known issues on gnu-toolchain for microblaze.
But mainly the incorrect (linker) relocation issues that emits invalid/incorrect code during optimizations.

Patches obtained from https://github.com/xilinx/meta-xilinx/ repository,
from `meta-microblaze/recipes-devtools/binutils` path.

This time around, I've intentionally skipped Microblaze64 patches for 2 reasons:
1. I don't intend to provide support nor maintain MB64. 
2. It's clearly an unstable hot mess. Even the patchset reflects that. Half of the patches are reverted in later patches.
