### PR TITLE
gdb/arm: Include FType bit in EXC_RETURN pattern on v8m

### DIFF
--- a/gdb/arm-tdep.c
+++ b/gdb/arm-tdep.c
@@ -533,13 +533,17 @@ arm_pc_is_thumb (struct gdbarch *gdbarch, CORE_ADDR memaddr)
    For more details see "B1.5.8 Exception return behavior"
    in both ARMv6-M and ARMv7-M Architecture Reference Manuals.
 
-   In the ARMv8-M Architecture Technical Reference also adds
-   for implementations without the Security Extension:
+   From ARMv8-M Architecture Technical Reference, D1.2.95
+   FType, Mode and SPSEL bits are to be considered when the Security
+   Extension is not implemented.
 
-   EXC_RETURN    Condition
-   0xFFFFFFB0    Return to Handler mode.
-   0xFFFFFFB8    Return to Thread mode using the main stack.
-   0xFFFFFFBC    Return to Thread mode using the process stack.  */
+   EXC_RETURN    Return To        Return Stack    Frame Type
+   0xFFFFFFA0    Handler mode     Main            Extended
+   0xFFFFFFA8    Thread mode      Main            Extended
+   0xFFFFFFAC    Thread mode      Process         Extended
+   0xFFFFFFB0    Handler mode     Main            Standard
+   0xFFFFFFB8    Thread mode      Main            Standard
+   0xFFFFFFBC    Thread mode      Process         Standard  */
 
 static int
 arm_m_addr_is_magic (CORE_ADDR addr)
@@ -547,6 +551,9 @@ arm_m_addr_is_magic (CORE_ADDR addr)
   switch (addr)
     {
       /* Values from ARMv8-M Architecture Technical Reference.  */
+      case 0xffffffa0:
+      case 0xffffffa8:
+      case 0xffffffac:
       case 0xffffffb0:
       case 0xffffffb8:
       case 0xffffffbc:


### PR DESCRIPTION
For v8m, the EXC_RETURN pattern, without security extension, consists of FType, Mode and SPSEL.  These are the same bits that are used in v7m. This patch extends the list of patterns to include also the FType bit and not just Mode and SPSEL bits for v8m targets without security extension.

Related issue: https://github.com/zephyrproject-rtos/sdk-ng/issues/994