### PR TITLE
gdbsupport: Handle -Wincompatible-function-pointer-types for Clang

### DIFF
--- a/bfd/configure
+++ b/bfd/configure
@@ -12261,6 +12261,20 @@ if test "${ERROR_ON_WARNING}" = yes ; then
     GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Werror"
     GCC_WARN_CFLAGS_FOR_BUILD="$GCC_WARN_CFLAGS_FOR_BUILD -Werror"
     NO_WERROR="-Wno-error"
+else
+    # Clang 16 and above treat -Wincompatible-function-pointer-types as an
+    # error regardless of -Werror being specified, so explicitly specify
+    # -Wno-error for it in case of --disable-werror.
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+__clang__
+_ACEOF
+if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
+  $EGREP "(^1$)" >/dev/null 2>&1; then :
+  GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Wno-error=incompatible-function-pointer-types"
+fi
+rm -f conftest*
+
 fi
 
 if test "${GCC}" = yes ; then

--- a/bfd/warning.m4
+++ b/bfd/warning.m4
@@ -95,6 +95,11 @@ if test "${ERROR_ON_WARNING}" = yes ; then
     GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Werror"
     GCC_WARN_CFLAGS_FOR_BUILD="$GCC_WARN_CFLAGS_FOR_BUILD -Werror"
     NO_WERROR="-Wno-error"
+else
+    # Clang 16 and above treat -Wincompatible-function-pointer-types as an
+    # error regardless of -Werror being specified, so explicitly specify
+    # -Wno-error for it in case of --disable-werror.
+    AC_EGREP_CPP([(^1$)],[__clang__],GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Wno-error=incompatible-function-pointer-types")
 fi
 
 if test "${GCC}" = yes ; then

--- a/binutils/configure
+++ b/binutils/configure
@@ -12436,6 +12436,20 @@ if test "${ERROR_ON_WARNING}" = yes ; then
     GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Werror"
     GCC_WARN_CFLAGS_FOR_BUILD="$GCC_WARN_CFLAGS_FOR_BUILD -Werror"
     NO_WERROR="-Wno-error"
+else
+    # Clang 16 and above treat -Wincompatible-function-pointer-types as an
+    # error regardless of -Werror being specified, so explicitly specify
+    # -Wno-error for it in case of --disable-werror.
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+__clang__
+_ACEOF
+if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
+  $EGREP "(^1$)" >/dev/null 2>&1; then :
+  GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Wno-error=incompatible-function-pointer-types"
+fi
+rm -f conftest*
+
 fi
 
 if test "${GCC}" = yes ; then

--- a/gas/configure
+++ b/gas/configure
@@ -11782,6 +11782,20 @@ if test "${ERROR_ON_WARNING}" = yes ; then
     GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Werror"
     GCC_WARN_CFLAGS_FOR_BUILD="$GCC_WARN_CFLAGS_FOR_BUILD -Werror"
     NO_WERROR="-Wno-error"
+else
+    # Clang 16 and above treat -Wincompatible-function-pointer-types as an
+    # error regardless of -Werror being specified, so explicitly specify
+    # -Wno-error for it in case of --disable-werror.
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+__clang__
+_ACEOF
+if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
+  $EGREP "(^1$)" >/dev/null 2>&1; then :
+  GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Wno-error=incompatible-function-pointer-types"
+fi
+rm -f conftest*
+
 fi
 
 if test "${GCC}" = yes ; then

--- a/gdb/configure
+++ b/gdb/configure
@@ -31268,6 +31268,11 @@ fi
 WERROR_CFLAGS=""
 if test "${ERROR_ON_WARNING}" = yes ; then
     WERROR_CFLAGS="-Werror"
+elif test "${GDB_COMPILER_TYPE}" = clang; then
+    # Clang 16 and above treat -Wincompatible-function-pointer-types as an
+    # error regardless of -Werror being specified, so explicitly specify
+    # -Wno-error for it in case of --disable-werror.
+    WERROR_CFLAGS="-Wno-error=incompatible-function-pointer-types"
 fi
 
 # The options we'll try to enable.

--- a/gdbserver/configure
+++ b/gdbserver/configure
@@ -13762,6 +13762,11 @@ fi
 WERROR_CFLAGS=""
 if test "${ERROR_ON_WARNING}" = yes ; then
     WERROR_CFLAGS="-Werror"
+elif test "${GDB_COMPILER_TYPE}" = clang; then
+    # Clang 16 and above treat -Wincompatible-function-pointer-types as an
+    # error regardless of -Werror being specified, so explicitly specify
+    # -Wno-error for it in case of --disable-werror.
+    WERROR_CFLAGS="-Wno-error=incompatible-function-pointer-types"
 fi
 
 # The options we'll try to enable.

--- a/gdbsupport/configure
+++ b/gdbsupport/configure
@@ -14230,6 +14230,11 @@ fi
 WERROR_CFLAGS=""
 if test "${ERROR_ON_WARNING}" = yes ; then
     WERROR_CFLAGS="-Werror"
+elif test "${GDB_COMPILER_TYPE}" = clang; then
+    # Clang 16 and above treat -Wincompatible-function-pointer-types as an
+    # error regardless of -Werror being specified, so explicitly specify
+    # -Wno-error for it in case of --disable-werror.
+    WERROR_CFLAGS="-Wno-error=incompatible-function-pointer-types"
 fi
 
 # The options we'll try to enable.

--- a/gdbsupport/warning.m4
+++ b/gdbsupport/warning.m4
@@ -33,6 +33,11 @@ fi
 WERROR_CFLAGS=""
 if test "${ERROR_ON_WARNING}" = yes ; then
     WERROR_CFLAGS="-Werror"
+elif test "${GDB_COMPILER_TYPE}" = clang; then
+    # Clang 16 and above treat -Wincompatible-function-pointer-types as an
+    # error regardless of -Werror being specified, so explicitly specify
+    # -Wno-error for it in case of --disable-werror.
+    WERROR_CFLAGS="-Wno-error=incompatible-function-pointer-types"
 fi
 
 # The options we'll try to enable.

--- a/gold/configure
+++ b/gold/configure
@@ -9950,6 +9950,20 @@ if test "${ERROR_ON_WARNING}" = yes ; then
     GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Werror"
     GCC_WARN_CFLAGS_FOR_BUILD="$GCC_WARN_CFLAGS_FOR_BUILD -Werror"
     NO_WERROR="-Wno-error"
+else
+    # Clang 16 and above treat -Wincompatible-function-pointer-types as an
+    # error regardless of -Werror being specified, so explicitly specify
+    # -Wno-error for it in case of --disable-werror.
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+__clang__
+_ACEOF
+if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
+  $EGREP "(^1$)" >/dev/null 2>&1; then :
+  GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Wno-error=incompatible-function-pointer-types"
+fi
+rm -f conftest*
+
 fi
 
 if test "${GCC}" = yes ; then

--- a/gprof/configure
+++ b/gprof/configure
@@ -13920,6 +13920,20 @@ if test "${ERROR_ON_WARNING}" = yes ; then
     GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Werror"
     GCC_WARN_CFLAGS_FOR_BUILD="$GCC_WARN_CFLAGS_FOR_BUILD -Werror"
     NO_WERROR="-Wno-error"
+else
+    # Clang 16 and above treat -Wincompatible-function-pointer-types as an
+    # error regardless of -Werror being specified, so explicitly specify
+    # -Wno-error for it in case of --disable-werror.
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+__clang__
+_ACEOF
+if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
+  $EGREP "(^1$)" >/dev/null 2>&1; then :
+  GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Wno-error=incompatible-function-pointer-types"
+fi
+rm -f conftest*
+
 fi
 
 if test "${GCC}" = yes ; then

--- a/ld/configure
+++ b/ld/configure
@@ -16094,6 +16094,20 @@ if test "${ERROR_ON_WARNING}" = yes ; then
     GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Werror"
     GCC_WARN_CFLAGS_FOR_BUILD="$GCC_WARN_CFLAGS_FOR_BUILD -Werror"
     NO_WERROR="-Wno-error"
+else
+    # Clang 16 and above treat -Wincompatible-function-pointer-types as an
+    # error regardless of -Werror being specified, so explicitly specify
+    # -Wno-error for it in case of --disable-werror.
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+__clang__
+_ACEOF
+if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
+  $EGREP "(^1$)" >/dev/null 2>&1; then :
+  GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Wno-error=incompatible-function-pointer-types"
+fi
+rm -f conftest*
+
 fi
 
 if test "${GCC}" = yes ; then

--- a/opcodes/configure
+++ b/opcodes/configure
@@ -11593,6 +11593,20 @@ if test "${ERROR_ON_WARNING}" = yes ; then
     GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Werror"
     GCC_WARN_CFLAGS_FOR_BUILD="$GCC_WARN_CFLAGS_FOR_BUILD -Werror"
     NO_WERROR="-Wno-error"
+else
+    # Clang 16 and above treat -Wincompatible-function-pointer-types as an
+    # error regardless of -Werror being specified, so explicitly specify
+    # -Wno-error for it in case of --disable-werror.
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+__clang__
+_ACEOF
+if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
+  $EGREP "(^1$)" >/dev/null 2>&1; then :
+  GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Wno-error=incompatible-function-pointer-types"
+fi
+rm -f conftest*
+
 fi
 
 if test "${GCC}" = yes ; then


### PR DESCRIPTION
Clang 16 and above always treat -Wincompatible-function-pointer-types as an error regardless of -Werror being specified [1], and this leads to build errors when building GDB with Clang in spite of having specified --disable-werror.

This corrects the above behaviour by explicitly specifying -Wno-error=incompatible-function-pointer-types when --disable-werror is specified.

[1] https://releases.llvm.org/16.0.0/tools/clang/docs/ReleaseNotes.html#id85