### PR TITLE
rx: Mismatch in rx_get_byte parameter type

### DIFF
--- a/opcodes/rx-dis.c
+++ b/opcodes/rx-dis.c
@@ -37,10 +37,9 @@ struct private
 };
 
 static int
-rx_get_byte (void * vdata)
+rx_get_byte (RX_Data *rx_data)
 {
   bfd_byte buf[1];
-  RX_Data *rx_data = (RX_Data *) vdata;
   int status;
 
   status = rx_data->dis->read_memory_func (rx_data->addr,


### PR DESCRIPTION
rx_decode_opcde wants something taking RX_Data *, not void *, and gcc complains. Fortunately, rx_get_byte actually wanted the same type, so the fix was simple.