### PR TITLE
gas: Recognize remaining openrisc TLS relocs in md_apply_fix

### DIFF
--- a/gas/config/tc-or1k.c
+++ b/gas/config/tc-or1k.c
@@ -368,11 +368,17 @@ or1k_apply_fix (struct fix *f, valueT *t, segT s)
     case BFD_RELOC_OR1K_TLS_LDO_HI16:
     case BFD_RELOC_OR1K_TLS_LDO_LO16:
     case BFD_RELOC_OR1K_TLS_IE_HI16:
+    case BFD_RELOC_OR1K_TLS_IE_AHI16:
     case BFD_RELOC_OR1K_TLS_IE_LO16:
     case BFD_RELOC_OR1K_TLS_IE_PG21:
     case BFD_RELOC_OR1K_TLS_IE_LO13:
     case BFD_RELOC_OR1K_TLS_LE_HI16:
+    case BFD_RELOC_OR1K_TLS_LE_AHI16:
     case BFD_RELOC_OR1K_TLS_LE_LO16:
+    case BFD_RELOC_OR1K_TLS_LE_SLO16:
+    case BFD_RELOC_OR1K_TLS_TPOFF:
+    case BFD_RELOC_OR1K_TLS_DTPOFF:
+    case BFD_RELOC_OR1K_TLS_DTPMOD:
       S_SET_THREAD_LOCAL (f->fx_addsy);
       break;
     default:


### PR DESCRIPTION
There were a few TLS relocation types which weren't included in the check for when to apply S_SET_THREAD_LOCAL in or1k_apply_fix. This caused files compiled with -ftls-model=local-exec to generate ELF files without having the extern _Thread_local symbols marked as TLS and caused link failures.