### PR TITLE
RISC-V: Add T-Head E907 extension support

### DIFF
--- a/bfd/elfxx-riscv.c
+++ b/bfd/elfxx-riscv.c
@@ -1270,6 +1270,10 @@ static struct riscv_implicit_subset riscv_implicit_subsets[] =
   {"svade", "+zicsr", check_implicit_always},
   {"svadu", "+zicsr", check_implicit_always},
   {"svbare", "+zicsr", check_implicit_always},
+
+  {"xtheade", "+xtheadcmo,+xtheadsync,+xtheadba,+xtheadbb,+xtheadbs,+xtheadcondmov,+xtheadmemidx,+xtheadfmv,+xtheadmac,+xtheadint", check_implicit_always},
+
+  {"zpsfoperand", "+zpn", check_implicit_always},
   {NULL, NULL, NULL}
 };
 
@@ -1424,6 +1428,8 @@ static struct riscv_supported_ext riscv_supported_std_z_ext[] =
   {"zcd",		ISA_SPEC_CLASS_DRAFT,		1, 0,  0 },
   {"zcmop",		ISA_SPEC_CLASS_DRAFT,		1, 0,  0 },
   {"zcmp",		ISA_SPEC_CLASS_DRAFT,		1, 0,  0 },
+  {"zpn",		ISA_SPEC_CLASS_DRAFT,		0, 9,  0 },
+  {"zpsfoperand",	ISA_SPEC_CLASS_DRAFT,		0, 9,  0 },
   {NULL, 0, 0, 0, 0}
 };
 
@@ -1471,6 +1477,7 @@ static struct riscv_supported_ext riscv_supported_vendor_x_ext[] =
   {"xcvelw",		ISA_SPEC_CLASS_DRAFT,	1, 0, 0 },
   {"xcvbi",		ISA_SPEC_CLASS_DRAFT,	1, 0, 0 },
   {"xcvmem",		ISA_SPEC_CLASS_DRAFT,	1, 0, 0 },
+  {"xtheade",		ISA_SPEC_CLASS_DRAFT,	1, 0, 0 },
   {"xtheadba",		ISA_SPEC_CLASS_DRAFT,	1, 0, 0 },
   {"xtheadbb",		ISA_SPEC_CLASS_DRAFT,	1, 0, 0 },
   {"xtheadbs",		ISA_SPEC_CLASS_DRAFT,	1, 0, 0 },


### PR DESCRIPTION
Add support for the xtheade umbrella vendor extension that implies all individual T-Head E-series extensions (xtheadcmo, xtheadsync, xtheadba, xtheadbb, xtheadbs, xtheadcondmov, xtheadmemidx, xtheadfmv, xtheadmac, xtheadint).

Also add Zpn and Zpsfoperand P-extension subsets (v0.9) used by the E907fp floating-point variant.